### PR TITLE
typo of doc of \gundef (fixes #16)

### DIFF
--- a/etoolbox.tex
+++ b/etoolbox.tex
@@ -239,7 +239,7 @@ Takes a control sequence name as its argument and forms a control sequence token
 
 Clears a \prm{command} such that \etex's \cmd{ifdefined} and \cmd{ifcsname} tests will consider it as undefined. This command is robust and may be prefixed with \cs{global}.
 
-\cmditem{undef}<command>
+\cmditem{gundef}<command>
 
 Similar to \cmd{undef} but acts globally.
 


### PR DESCRIPTION
Added missing "g" in cs name of \gundef.