### PR TITLE
Add support for \NewCommandCopy

### DIFF
--- a/etoolbox.sty
+++ b/etoolbox.sty
@@ -878,6 +878,45 @@
      \csname#2\endcsname}
     {\csundef{#1}}}
 
+\ifdef\NewCommandCopy
+  {%
+    \def\etb@carsquare#1#2#3\@nil{#1#2}
+    %
+    % {<cstoken>}{<true>}{<false>}
+    %
+    \newrobustcmd*{\etb@if@robustcmd}[1]{%
+      \begingroup
+        \escapechar=`\\
+        \edef\etb@tempa{%
+      \endgroup
+      \def\noexpand\etb@tempa{\noexpand\@testopt
+        \expandafter\noexpand\csname\string#1\endcsname}%
+      \def\noexpand\etb@tempb{\unexpanded\expandafter\expandafter\expandafter
+        {\expandafter\etb@carsquare#1{}{}\@nil}}%
+      }\etb@tempa
+      \ifx\etb@tempa\etb@tempb
+        \expandafter\@firstoftwo
+      \else
+        \expandafter\@secondoftwo
+      \fi}
+    %
+    % {<cstoken>}{<cstoken>}
+    %
+    \newrobustcmd*{\etb@copy@robustcmd}[2]{%
+      \begingroup
+        \escapechar=`\\
+        \edef\etb@tempa{%
+      \endgroup
+      \protected\def\noexpand#1{\noexpand\@testopt
+        \expandafter\noexpand\csname\string#1\endcsname
+        \unexpanded\expandafter\expandafter\expandafter
+          {\expandafter\@gobbletwo#2}}%
+      \let\expandafter\noexpand\csname\string#1\endcsname
+          \expandafter\noexpand\csname\string#2\endcsname
+      }\etb@tempa}
+    \g@addto@macro\@declarecommandcopylisthook
+      {{\etb@if@robustcmd\etb@copy@robustcmd}}
+  }{}
 % {<csname>}
 
 \newcommand*{\csuse}[1]{%

--- a/testfiles/etoolbox-cmdcopy.dev.tlg
+++ b/testfiles/etoolbox-cmdcopy.dev.tlg
@@ -1,0 +1,10 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+\tmp=\protected macro:->\@testopt \\tmp {zzz}|
+\\tmp=\long macro:[#1]->boo|
+\+=\protected macro:->\@testopt \\+ {zzz}|
+\\+=\long macro:[#1]->boo|
+\tmp=\protected macro:->\@testopt \\tmp {zzz}|
+\\tmp=\long macro:[#1]->boo|
+\+=\protected macro:->\@testopt \\+ {zzz}|
+\\+=\long macro:[#1]->boo|

--- a/testfiles/etoolbox-cmdcopy.lvt
+++ b/testfiles/etoolbox-cmdcopy.lvt
@@ -1,0 +1,36 @@
+\input regression-test
+\RequirePackage{etoolbox}
+
+\START
+
+\ifdef\DeclareCommandCopy{}{\END}
+
+\def\testt#1#2#3#4{%
+  #4%
+  \DeclareCommandCopy#1#3%
+  \testtt#1
+  \expandafter\testtt\csname\string#1\endcsname
+  \typeout{}}
+\def\testtt#1{%
+  \typeout{\string#1=\meaning#1|}%
+  \let#1\undefined}
+
+\def\cmdd{defined}
+
+% Here we need control words
+\testt\tmp{tmp}\cmdd
+{\renewrobustcmd\cmdd[1][zzz]{boo}}
+
+% And here control symbols
+\testt\+{+}\%
+{\renewrobustcmd\%[1][zzz]{boo}}
+
+% Test letting a control symbol to a control word
+\testt\tmp{tmp}\%
+{\renewrobustcmd\%[1][zzz]{boo}}
+
+% And a control word to a control symbol
+\testt\+{+}\cmdd
+{\renewrobustcmd\cmdd[1][zzz]{boo}}
+
+\END

--- a/testfiles/etoolbox-cmdcopy.tlg
+++ b/testfiles/etoolbox-cmdcopy.tlg
@@ -1,0 +1,2 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.


### PR DESCRIPTION
This pull request adds `\NewCommandCopy` support for `\newrobustcmd`-defined commands.  Two macros are defined here:

 - `\etb@if@robustcmd<cstoken>{<true>}{<false>}` checks if `<cstoken>` is a `\newrobustcmd`-defined macro, and returns the appropriate conditional branch.

 - `\etb@copy@robustcmd<cstoken-to><cstoken-from>` copies `<cstoken-from>` to `<cstoken-to>` as well as the internal structure for the case of an optional argument.

These macros do _not_ work as a general-purpose “is this macro defined with `\newrobustcmd`, then copy it” because they may fail for macros with parameters, as other conditionals of the same type implemented in the LaTeX kernel.  Thus the choice to make them internal macros.