### PR TITLE
Handle hash symbols properly in \eappto

### DIFF
--- a/etoolbox.sty
+++ b/etoolbox.sty
@@ -942,16 +942,16 @@
     {\edef#1{\expandonce#1\unexpanded{#2}}}}
 \newrobustcmd{\eappto}[2]{%
   \ifundef{#1}
-    {\edef#1{#2}}
-    {\edef#1{\expandonce#1#2}}}
+    {\edef#1{\expandonce{\expanded{#2}}}}
+    {\edef#1{\expandonce#1\expandonce{\expanded{#2}}}}}
 \newrobustcmd{\gappto}[2]{%
   \ifundef{#1}
     {\xdef#1{\unexpanded{#2}}}
     {\xdef#1{\expandonce#1\unexpanded{#2}}}}
 \newrobustcmd{\xappto}[2]{%
   \ifundef{#1}
-    {\xdef#1{#2}}
-    {\xdef#1{\expandonce#1#2}}}
+    {\xdef#1{\expandonce{\expanded{#2}}}}
+    {\xdef#1{\expandonce#1\expandonce{\expanded{#2}}}}}
 
 \newrobustcmd*{\protected@eappto}{\etb@protected\eappto}
 \newrobustcmd*{\protected@xappto}{\etb@protected\xappto}
@@ -964,16 +964,16 @@
     {\edef#1{\unexpanded{#2}\expandonce#1}}}
 \newrobustcmd{\epreto}[2]{%
   \ifundef{#1}
-    {\edef#1{#2}}
-    {\edef#1{#2\expandonce#1}}}
+    {\edef#1{\expandonce{\expanded{#2}}}}
+    {\edef#1{\expandonce{\expanded{#2}}\expandonce#1}}}
 \newrobustcmd{\gpreto}[2]{%
   \ifundef{#1}
     {\xdef#1{\unexpanded{#2}}}
     {\xdef#1{\unexpanded{#2}\expandonce#1}}}
 \newrobustcmd{\xpreto}[2]{%
   \ifundef{#1}
-    {\xdef#1{#2}}
-    {\xdef#1{#2\expandonce#1}}}
+    {\xdef#1{\expandonce{\expanded{#2}}}}
+    {\xdef#1{\expandonce{\expanded{#2}}\expandonce#1}}}
 
 \newrobustcmd*{\protected@epreto}{\etb@protected\epreto}
 \newrobustcmd*{\protected@xpreto}{\etb@protected\xpreto}

--- a/testfiles/etoolbox-eappto.lvt
+++ b/testfiles/etoolbox-eappto.lvt
@@ -18,9 +18,9 @@
     \TYPE{\mmeaning\test}
     \eappto\test{\inputb\inputc}
     \TYPE{\mmeaning\test}
-    \eappto\test{(\unexpanded{\inputd}= \inputd)}
+    \eappto\test{(\noexpand\inputd = \inputd)}
     \TYPE{\mmeaning\test}
-    \eappto\test{(\expandonce{\inputee}= \inputee)}
+    \eappto\test{(\expandonce\inputee = \inputee)}
     \TYPE{\mmeaning\test}
     \eappto\test{\the\toks0}
     \TYPE{\mmeaning\test}
@@ -33,9 +33,9 @@
     \TYPE{\mmeaning\test}
     \epreto\test{\inputb\inputc}
     \TYPE{\mmeaning\test}
-    \epreto\test{(\unexpanded{\inputd}= \inputd)}
+    \epreto\test{(\noexpand\inputd = \inputd)}
     \TYPE{\mmeaning\test}
-    \epreto\test{(\expandonce{\inputee}= \inputee)}
+    \epreto\test{(\expandonce\inputee = \inputee)}
     \TYPE{\mmeaning\test}
     \epreto\test{\the\toks0}
     \TYPE{\mmeaning\test}

--- a/testfiles/etoolbox-eappto.lvt
+++ b/testfiles/etoolbox-eappto.lvt
@@ -1,0 +1,64 @@
+\input{regression-test}
+\RequirePackage{etoolbox}
+
+\START
+
+\def\mmeaning#1{\string#1\space= {\meaning#1}}
+\def\inputa{a}
+\def\inputb{b}
+\def\inputc{c}
+\def\inputd{d}
+\def\inpute{e}
+\def\inputee{\inpute}
+\toks0={\unexpandingmacro}
+
+\TEST{\eappto regression test}{
+    \TYPE{\mmeaning\test}
+    \eappto\test{\inputa}
+    \TYPE{\mmeaning\test}
+    \eappto\test{\inputb\inputc}
+    \TYPE{\mmeaning\test}
+    \eappto\test{(\unexpanded{\inputd}= \inputd)}
+    \TYPE{\mmeaning\test}
+    \eappto\test{(\expandonce{\inputee}= \inputee)}
+    \TYPE{\mmeaning\test}
+    \eappto\test{\the\toks0}
+    \TYPE{\mmeaning\test}
+}
+
+\TEST{\epreto regression test}{
+    \let\test\undefined
+    \TYPE{\mmeaning\test}
+    \epreto\test{\inputa}
+    \TYPE{\mmeaning\test}
+    \epreto\test{\inputb\inputc}
+    \TYPE{\mmeaning\test}
+    \epreto\test{(\unexpanded{\inputd}= \inputd)}
+    \TYPE{\mmeaning\test}
+    \epreto\test{(\expandonce{\inputee}= \inputee)}
+    \TYPE{\mmeaning\test}
+    \epreto\test{\the\toks0}
+    \TYPE{\mmeaning\test}
+}
+
+\TEST{\eappto & \epreto with hash symbols}{
+    \def\two{four}
+    \def\four{eight}
+    \let\test\undefined
+    \eappto\test{
+        \unexpanded{\edef\lazyedef}{
+            only \unexpanded{\two} hash symbols (##) needed to escape
+            instead of \unexpanded{\four}}
+    }
+    \epreto\test{
+        \unexpanded{\def\lazydef#1#2}{do something with #1 and #2}
+    }
+    \def\two{two}
+    \def\four{four}
+    \test
+    \TYPE{\mmeaning\lazyedef}
+    \TYPE{\mmeaning\lazydef}
+    \TYPE{\string\lazydef{arg1}{arg2} = \lazydef{arg1}{arg2}}
+}
+
+\END

--- a/testfiles/etoolbox-eappto.tlg
+++ b/testfiles/etoolbox-eappto.tlg
@@ -1,0 +1,29 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: \eappto regression test
+============================================================
+\test = {undefined}
+\test = {macro:->a}
+\test = {macro:->abc}
+\test = {macro:->abc(\inputd = d)}
+\test = {macro:->abc(\inputd = d)(\inpute = e)}
+\test = {macro:->abc(\inputd = d)(\inpute = e)\unexpandingmacro }
+============================================================
+============================================================
+TEST 2: \epreto regression test
+============================================================
+\test = {undefined}
+\test = {macro:->a}
+\test = {macro:->bca}
+\test = {macro:->(\inputd = d)bca}
+\test = {macro:->(\inpute = e)(\inputd = d)bca}
+\test = {macro:->\unexpandingmacro (\inpute = e)(\inputd = d)bca}
+============================================================
+============================================================
+TEST 3: \eappto & \epreto with hash symbols
+============================================================
+\lazyedef = {macro:-> only two hash symbols (##) needed to escape instead of four}
+\lazydef = {macro:#1#2->do something with #1 and #2}
+\lazydef{arg1}{arg2} = do something with arg1 and arg2
+============================================================


### PR DESCRIPTION
Currently, `\eappto` (and `\epreto`, `\xappto`, etc.) requires hash symbols `#` to be doubled, which is definitely an unintended behaviour since the command to expand cannot have arguments in the first place.

Consider the following examples.
Handling of hash symbols in `\appto` works as it should:
```latex
\appto\testA{
    \def\lazydef#1{do something with #1}}
\testA
\meaning\lazydef % macro:#1->do something with #1
```
However, to achieve the same thing with `\eappto`, you need to double the hash symbols:
```latex
\eappto\testB{
    \unexpanded{\def\lazydef#1}{do something with ##1}}
\testB
\meaning\lazydef % macro:#1->do something with #1
```
That would only make sense if `#1` had a meaning within the second argument of `\eappto`.
```latex
\appto\testC{what would #1 mean here?}
\testC % what would ##1 mean here?
\eappto\testD{what would #1 mean here?} % ! Illegal parameter number in definition of \testD.
```
Obviously, it cannot have any meaning, since `testD` cannot have any arguments to be used with `\eappto` in the first place.